### PR TITLE
Create index on syncapi_send_to_device table with user_id and device_id

### DIFF
--- a/syncapi/storage/postgres/send_to_device_table.go
+++ b/syncapi/storage/postgres/send_to_device_table.go
@@ -41,6 +41,8 @@ CREATE TABLE IF NOT EXISTS syncapi_send_to_device (
 	-- The event content JSON.
 	content TEXT NOT NULL
 );
+
+CREATE INDEX IF NOT EXISTS syncapi_send_to_device_user_id_device_id_idx ON syncapi_send_to_device(user_id, device_id);
 `
 
 const insertSendToDeviceMessageSQL = `


### PR DESCRIPTION
Following query:
```
SELECT id, user_id, device_id, content
FROM syncapi_send_to_device
WHERE user_id = '@1:dendrite.stg.globekeeper.com' AND device_id = 'TRsKdsIB';
```
took ~80ms before and ~15ms after index creation.