### PR TITLE
🌐 Forward IP for login/register device creation (external API)

### DIFF
--- a/internal/httputil/httpapi.go
+++ b/internal/httputil/httpapi.go
@@ -239,6 +239,9 @@ func MakeExternalAPI(metricsName string, f func(*http.Request) util.JSONResponse
 		span := opentracing.StartSpan(metricsName)
 		defer span.Finish()
 		req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
+		if forwardedFor := req.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+			req.RemoteAddr = forwardedFor
+		}
 		h.ServeHTTP(nextWriter, req)
 
 	}

--- a/syncapi/storage/sqlite3/account_data_table.go
+++ b/syncapi/storage/sqlite3/account_data_table.go
@@ -105,7 +105,9 @@ func (s *accountDataStatements) SelectAccountDataInRange(
 		filter.Senders, filter.NotSenders,
 		filter.Types, filter.NotTypes,
 		[]string{}, nil, filter.Limit, FilterOrderAsc)
-
+	if err != nil {
+		return
+	}
 	rows, err := stmt.QueryContext(ctx, params...)
 	if err != nil {
 		return

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -191,6 +191,9 @@ func (rp *RequestPool) updateLastSeen(req *http.Request, device *userapi.Device)
 		return
 	}
 
+	if forwardedFor := req.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+		req.RemoteAddr = forwardedFor
+	}
 	remoteAddr := req.RemoteAddr
 	if rp.cfg.RealIPHeader != "" {
 		if header := req.Header.Get(rp.cfg.RealIPHeader); header != "" {


### PR DESCRIPTION
Along with [this commit](https://bitbucket.org/globekeeper/sre/commits/a5856c6c5a2ae6095d79dbf61043b073578a7dda) from `SRE`, now Dendrite will keep public IPs instead of proxied IP associated with users' devices, and also update the last seen IPs (which are updated upon every `/sync` request) accordingly.