### PR TITLE
Revert "Add CS API device tests (#3029)"

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Build upgrade-tests
         run: go build ./cmd/dendrite-upgrade-tests
       - name: Test upgrade (PostgreSQL)
-        run: ./dendrite-upgrade-tests --head .
+        run: ./dendrite-upgrade-tests .
 
   # run database upgrade tests, skipping over one version
   upgrade_test_direct:
@@ -301,7 +301,7 @@ jobs:
       - name: Build upgrade-tests
         run: go build ./cmd/dendrite-upgrade-tests
       - name: Test upgrade (PostgreSQL)
-        run: ./dendrite-upgrade-tests -direct -from HEAD-2 --head .
+        run: ./dendrite-upgrade-tests -direct -from HEAD-2 .
 
   # run Sytest in different variations
   sytest:

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -1175,7 +1175,7 @@ func Setup(
 
 	v3mux.Handle("/delete_devices",
 		httputil.MakeAuthAPI("delete_devices", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return DeleteDevices(req, userInteractiveAuth, userAPI, device)
+			return DeleteDevices(req, userAPI, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 


### PR DESCRIPTION
Reverting the user-interactive `/delete_devices` on the same branch used for v0.13.1 upstream changes.