### PR TITLE
🏗️ Send origin server timestamp header on multiroom data.

### DIFF
--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -167,7 +167,8 @@ func (p *SyncAPIProducer) SendMultiroom(
 ) error {
 	m := nats.NewMsg(p.TopicMultiRoomCast)
 	m.Header.Set(jetstream.UserID, userID)
-	m.Header.Set("type", dataType)
+	m.Header.Set(jetstream.Type, dataType)
+	m.Header.Set(jetstream.Timestamp, strconv.Itoa(int(spec.AsTimestamp(time.Now()))))
 	m.Data = message
 	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
 	return err

--- a/setup/jetstream/streams.go
+++ b/setup/jetstream/streams.go
@@ -10,6 +10,8 @@ import (
 
 const (
 	UserID        = "user_id"
+	Type          = "type"
+	Timestamp     = "ts"
 	RoomID        = "room_id"
 	EventID       = "event_id"
 	RoomEventType = "output_room_event_type"


### PR DESCRIPTION
This is not the clients' timestamps, but it's something I guess.
@danpe WDYT? Do we need the MQTT location updates to contain the timestamp of arrival of location update to Dendrite? I know you don't like to modify Dendrite, but in this case we aren't removing anything or changing logics, only adding a header to the Nats message being published.